### PR TITLE
Sales registration and filters

### DIFF
--- a/sales/validation.py
+++ b/sales/validation.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from datetime import datetime
-from decimal import Decimal
+from decimal import Inexact
 from enum import Enum
-from typing import Self
+from typing import Optional, Self
 from bson import Decimal128, ObjectId
 from bson.errors import InvalidId
 
@@ -14,13 +14,34 @@ class AnonymousUser:
     addr: str
     cep: str
     email: str
-    city: str | None
-    state: str | None
-    tel: str | None
+    city: Optional[str] = None
+    state: Optional[str] = None
+    tel: Optional[str] = None
 
     @staticmethod
     def from_dict(d: dict[str, str]) -> Self:
-        return AnonymousUser(**d)
+        if d is None:
+            raise AssertionError("Expected 'customer' dict, got None instead")
+        for k, v in d.items():
+            if not isinstance(v, str):
+                raise AssertionError(f"Invalid field 'customer.{k}': {v} <{type(v)}>")
+
+        try:
+            return AnonymousUser(**d)
+        except TypeError as error:
+            raise AssertionError(error)
+
+    def to_json(self) -> dict[str, str]:
+        return {
+            "name": self.name,
+            "surname": self.surname,
+            "addr": self.addr,
+            "cep": self.cep,
+            "email": self.email,
+            "city": self.city,
+            "state": self.state,
+            "tel": self.tel,
+        }
 
 
 @dataclass
@@ -32,21 +53,26 @@ class SaleItem:
     _required = ["id", "price", "qty"]
 
     @staticmethod
-    def from_dict(d: dict[str, str]) -> Self:
-        for field in d:
-            if field not in SaleItem._required:
+    def from_dict(d: dict[str, str | float | int]) -> Self:
+        for field in SaleItem._required:
+            if field not in d:
                 raise AssertionError(f"Missing field '{field}' for SaleItem")
 
         try:
             _id = ObjectId(d["id"])
+            _price = Decimal128(str(d["price"]))
         except InvalidId:
             raise AssertionError(f"Invalid oid for SaleItem: '{d['id']}'")
+        except Inexact:
+            raise AssertionError(f"Failed price to cast to Decimal128: {d['qty']}")
 
-        return SaleItem(_id, Decimal128(Decimal(d["price"])), d["qty"])
+        return SaleItem(_id, _price, d["qty"])
 
-    def to_dict(self) -> dict[str,]:
+    def to_json(self) -> dict[str, str | float | int]:
         return {
-            "_id": ObjectId(self.id),
+            "_id": str(self.id),
+            "price": float(self.price.to_decimal()),
+            "qty": self.qty,
         }
 
 

--- a/sales/validation.py
+++ b/sales/validation.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Self
+from bson import Decimal128, ObjectId
+from bson.errors import InvalidId
+
+
+@dataclass
+class AnonymousUser:
+    name: str
+    surname: str
+    addr: str
+    cep: str
+    email: str
+    city: str | None
+    state: str | None
+    tel: str | None
+
+    @staticmethod
+    def from_dict(d: dict[str, str]) -> Self:
+        return AnonymousUser(**d)
+
+
+@dataclass
+class SaleItem:
+    id: ObjectId
+    price: Decimal128
+    qty: int
+
+    _required = ["id", "price", "qty"]
+
+    @staticmethod
+    def from_dict(d: dict[str, str]) -> Self:
+        for field in d:
+            if field not in SaleItem._required:
+                raise AssertionError(f"Missing field '{field}' for SaleItem")
+
+        try:
+            _id = ObjectId(d["id"])
+        except InvalidId:
+            raise AssertionError(f"Invalid oid for SaleItem: '{d['id']}'")
+
+        return SaleItem(_id, Decimal128(Decimal(d["price"])), d["qty"])
+
+    def to_dict(self) -> dict[str,]:
+        return {
+            "_id": ObjectId(self.id),
+        }
+
+
+class PaymentMethod(Enum):
+    DEBIT = "debit"
+    CREDIT = "credit"
+    PIX = "pix"
+
+
+class SaleStatus(Enum):
+    PROGRESS = 0
+    DONE = 1
+    CANCELLED = 2
+
+
+class Sale:
+    customer: ObjectId | AnonymousUser
+    items: list[SaleItem]
+    tax: Decimal128
+    shipping: Decimal128
+    shipping_provider: str
+    payment_method: PaymentMethod
+    payment_provider: str | None
+    status: SaleStatus
+    date: datetime

--- a/sales/views.py
+++ b/sales/views.py
@@ -8,7 +8,7 @@ from connections import db
 from sales.validation import Sale
 
 sales = Blueprint("sales", __name__)
-collection = db["orders_payment_details"]
+collection = db["orders"]
 customer_collection = db["users"]
 
 
@@ -25,7 +25,7 @@ BASE_QUERY = [
             ],
         }
     },
-    {"$unset": ["id_customer"]},
+    {"$unset": ["customer_id"]},
     {
         "$set": {
             "user": {"$arrayElemAt": ["$user", 0]},

--- a/sales/views.py
+++ b/sales/views.py
@@ -1,11 +1,11 @@
 from collections import defaultdict
 from datetime import datetime
-from bson import Decimal128, ObjectId, Regex
-from flask import Blueprint, current_app, jsonify, request
-import jwt
+
+from bson import Regex
+from flask import Blueprint, jsonify, request
 
 from connections import db
-from sales.validation import AnonymousUser, Sale, SaleItem
+from sales.validation import Sale
 
 sales = Blueprint("sales", __name__)
 collection = db["orders_payment_details"]
@@ -79,7 +79,7 @@ def register_sale():
     except (AssertionError, ValueError) as e:
         return jsonify({"message": str(e)}), 400
 
-    _id = collection.insert_one(sale).inserted_id
+    _id = collection.insert_one(sale.to_bson()).inserted_id
 
     return jsonify({"message": f"Order successfully recorded: {_id}"}), 200
 

--- a/sales/views.py
+++ b/sales/views.py
@@ -41,6 +41,7 @@ BASE_QUERY = [
                 }
             },
             "tax": {"$toDouble": "$tax"},
+            "shipping": {"$toDouble": "$shipping"},
             "_id": {"$toString": "$_id"},
             "total": {
                 "$toDouble": {


### PR DESCRIPTION
## Registrando uma venda

Envie uma requisição `POST` para `/sales/new`. Opcionalmente, envie um token de autenticação no header `Authorization` para associar o usuário que fez a aquisição. Caso o usuário não tenha um login, preencha o campo `customer`. Ou _Authorization_ ou _customer_ devem estar presentes, mas não ambos.

`customer` tem 8 campos totais. Campos obrigatórios: _name_, _surname_, _addr_, _cep_ e _email_. Campos opcionais: _city_, _state_, _tel_.

`status` representa o estado da venda no sistema.

- 0: Em andamento
- 1: Finalizada
- 2: Cancelada

`payment_method` e `payment_provider` são interligados. O método pode ser _credit_, _debit_ ou _pix_, e o provedor é a bandeira do cartão, não sendo validada exaustivamente. Caso o método de pagamento seja PIX, o provedor não deve ser incluído.

```json
{
  "customer": {
    "name": "Pedro",
    "surname": "Gonzaga",
    "addr": "Palácio de São Cristóvão",
    "cep": "20941070"
    "email": "pedro.gonzaga2@gov.br"
  },
  "items": [
    { "id": "<species_id>", "qty": 4 }
  ],
  "status": 0,
  "tax": 10,
  "shipping": 8.99,
  "payment_method": "debit",
  "payment_provider": "visa"
}
```

## Filtrando vendas

Envie uma requisição GET para `/sales/filter` com os filtros como parte dos parâmetros GET. Utilizando JavaScript, é possível gerar a formatação dos parâmetros a partir de um objeto:

```js
const filters = {"username": "Willy Wonka", "status": 0};
const params = new URLSearchParams(filters);
const res = await fetch(`${API_URL}/sales/filter?${params.toString()}`);
```

Por padrão, são retornados apenas os 20 primeiros resultados. Isso é uma função de paginação e evita o carregamento excessivo de dados. `count` controla o número de resultados e `page` alterna o _offset_, ou seja, os próximos _count_ resultados.

Segue uma lista de todos os filtros suportados:
- `username`: nome do usuário que fez a aquisição;
- `min` e `max`: valores mínimo e máximo da venda (contanto impostos e frete);
- `products`: lista separada por vírgulas dos IDs dos produtos que pertencem ao carrinho da compra;
- `status`: 0, 1 ou 2, conforme o protocolo descrito acima;
- `min_date` e `max_date`: timestamps Unix da data e hora em que a venda foi efetivada;
- `ordering`: lista separada por vírgulas dos critérios de ordenação. Por padrão, ordena pelo ID da venda. Os índices de ordenação disponíveis são: _total_, _date_ e _user.name_. Um prefixo `+` descreve uma ordenação crescente, enquanto `-` descreve uma ordenação decrescente;
- `count`: número de resultados retornados. 20 por padrão;
- `page`: _offset_ dos resultados. 1 por padrão, ou seja, mostra a range [0..20); já a página 2 retornaria a range [20..40).